### PR TITLE
Transport logger registration

### DIFF
--- a/src/golare.erl
+++ b/src/golare.erl
@@ -19,7 +19,6 @@ start(normal, _StartArgs) ->
     ok = set_context(),
     ok = set_global_scopes(),
     ok = set_process_scopes(),
-    ok = add_logger(),
     golare_sup:start_link().
 
 stop(_State) ->
@@ -70,13 +69,3 @@ set_context() ->
         runtime => Runtime
     },
     persistent_term:put({golare, contexts}, Context).
-
-add_logger() ->
-    Level = golare_config:logger_level(),
-    Config = #{
-        config => #{},
-        level => Level,
-        filter_default => log,
-        filters => [{golare, {fun logger_filters:domain/2, {stop, sub, [golare]}}}]
-    },
-    ok = logger:add_handler(golare, golare_logger_h, Config).

--- a/src/golare_logger_h.erl
+++ b/src/golare_logger_h.erl
@@ -34,6 +34,8 @@ log(#{level := Level} = LogEvent, _Config) ->
         Event = maps:merge(Event0, describe(LogEvent)),
         {ok, _EventId} = golare:capture_event(Event)
     catch
+        exit:{noproc, _} ->
+            ok;
         Type:Rsn:Trace ->
             Crash = #{
                 logger => ?MODULE,

--- a/src/golare_transport.erl
+++ b/src/golare_transport.erl
@@ -304,7 +304,7 @@ overflow(Q, MaxLen) ->
     end.
 
 add_logger() ->
-    case logger:get_handler_config(golare_logger_h) of
+    case logger:get_handler_config(golare) of
         {ok, _Config} ->
             ok;
         {error, {not_found, _}} ->

--- a/src/golare_transport.erl
+++ b/src/golare_transport.erl
@@ -304,14 +304,19 @@ overflow(Q, MaxLen) ->
     end.
 
 add_logger() ->
-    Level = golare_config:logger_level(),
-    Config = #{
-        config => #{},
-        level => Level,
-        filter_default => log,
-        filters => [{golare, {fun logger_filters:domain/2, {stop, sub, [golare]}}}]
-    },
-    ok = logger:add_handler(golare, golare_logger_h, Config).
+    case logger:get_handler_config(golare_logger_h) of
+        {ok, _Config} ->
+            ok;
+        {error, {not_found, _}} ->
+            Level = golare_config:logger_level(),
+            Config = #{
+                config => #{},
+                level => Level,
+                filter_default => log,
+                filters => [{golare, {fun logger_filters:domain/2, {stop, sub, [golare]}}}]
+            },
+            ok = logger:add_handler(golare, golare_logger_h, Config)
+    end.
 
 remove_logger() ->
     _ = logger:remove_handler(golare),

--- a/src/golare_transport.erl
+++ b/src/golare_transport.erl
@@ -62,6 +62,7 @@ capture(Capture) ->
 
 init([]) ->
     quickrand_cache:init(),
+    ok = add_logger(),
     State = #data{
         dsn = golare_config:dsn(),
         q = queue:new(),
@@ -76,6 +77,7 @@ init([]) ->
     {ok, started, State, Actions}.
 
 terminate(_Reason, _State, _Data) ->
+    ok = remove_logger(),
     ok.
 
 format_status(Status) ->
@@ -300,3 +302,17 @@ overflow(Q, MaxLen) ->
         _ ->
             Q
     end.
+
+add_logger() ->
+    Level = golare_config:logger_level(),
+    Config = #{
+        config => #{},
+        level => Level,
+        filter_default => log,
+        filters => [{golare, {fun logger_filters:domain/2, {stop, sub, [golare]}}}]
+    },
+    ok = logger:add_handler(golare, golare_logger_h, Config).
+
+remove_logger() ->
+    _ = logger:remove_handler(golare),
+    ok.


### PR DESCRIPTION
if a logger gets noproc trying to capture, maybe it is because transport layer has terminated.

register the logger from the transport layer, and de-register when transport layer terminates.

if a logger is already registered, then dont register again