### PR TITLE
fix: dont present log entries with mfa as sentry exceptions

### DIFF
--- a/src/golare_logger_h.erl
+++ b/src/golare_logger_h.erl
@@ -305,19 +305,6 @@ describe_log(E0, Message, Report, Meta) when is_map(Report) ->
         extra => #{K => print(V) || K := V <- Report, is_atom(K)}
     }.
 
-maybe_mfa(E0, Message, #{mfa := {Mod, Fun, A}, file := Filename, line := Line}) ->
-    Value = #{
-        type => print(Message),
-        stacktrace => #{
-            frames => [
-                frame({Mod, Fun, A, [{filename, Filename}, {line, Line}]})
-            ]
-        }
-    },
-    Exception = #{values => [Value]},
-    E0#{
-        exception => Exception
-    };
 maybe_mfa(E0, _Message, _Meta) ->
     E0.
 

--- a/test/crashy_server.erl
+++ b/test/crashy_server.erl
@@ -9,6 +9,8 @@
 -export([start_link/0]).
 -export([childspec/0]).
 
+-include_lib("kernel/include/logger.hrl").
+
 start_link() ->
     Opts = [],
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], Opts).
@@ -23,6 +25,15 @@ childspec() ->
 init(_Args) ->
     {ok, #{}}.
 
+handle_call({log_error, Message}, _From, State) ->
+    ?LOG_ERROR(#{message => Message}),
+    {reply, ok, State};
+handle_call({log_warning, Message}, _From, State) ->
+    ?LOG_WARNING(#{message => Message}),
+    {reply, ok, State};
+handle_call({log_info, Message}, _From, State) ->
+    ?LOG_INFO(#{message => Message}),
+    {reply, ok, State};
 handle_call({exit, Reason}, _From, _State) ->
     exit(Reason);
 handle_call({error, Reason}, _From, _State) ->


### PR DESCRIPTION
it wasnt productive to make log entries look like exceptions when they come with the mfa/line/file meta values as the `LOG_*` macros of the otp logger

maybe the values should be added to something that goes into the extras/additional values kv-list
