### PR TITLE
feat: Add composable interface API

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -14,7 +14,8 @@
 {deps, [
     {uuid, "2.0.7", {pkg, uuid_erl}},
     {certifi, "2.15.0"},
-    {gun, {git, "https://github.com/ninenines/gun.git", {tag, "2.2.0"}}}
+    {gun, {git, "https://github.com/ninenines/gun.git", {tag, "2.2.0"}}},
+    {mapz, "2.4.0"}
 ]}.
 
 {dialyzer, [

--- a/src/golare.erl
+++ b/src/golare.erl
@@ -9,6 +9,7 @@
 
 -export([start/2, stop/1]).
 
+-export([event/2]).
 -export([capture_event/1]).
 
 -export([test_logger/1]).
@@ -24,6 +25,36 @@ start(normal, _StartArgs) ->
 stop(_State) ->
     ok.
 
+-doc "Compose a Sentry event from attributes and interface objects.".
+-spec event(Attrs, Interfaces) -> Event when
+    Attrs :: #{atom() => term()},
+    Interfaces :: [golare_interface:t()],
+    Event :: map().
+event(Attrs, Interfaces) ->
+    Attributes = [
+        {required, timestamp},
+        {optional, level}
+    ],
+    Event = lists:foldl(fun(Attr, Acc) -> attr(Attr, Attrs, Acc) end, #{}, Attributes),
+    mapz:deep_merge([Event|Interfaces]).
+
+attr({_, Key}, Attrs, Acc) when is_map_key(Key, Attrs) ->
+    Value = maps:get(Key, Attrs),
+    case is_valid(Key, Value) of
+        true -> Acc#{Key => Value};
+        false -> error({invalid_attr, Key, Value})
+    end;
+attr({required, Key}, _Attrs, Acc) ->
+    Acc#{Key => default(Key)};
+attr({optional, _Attr}, _Attrs, Acc) ->
+    Acc.
+
+is_valid(timestamp, Value) -> is_integer(Value) orelse is_binary(Value);
+is_valid(level, Value) -> is_atom(Value).
+
+default(timestamp) -> erlang:system_time(second).
+
+-spec capture_event(json:encode_value()) -> ok.
 capture_event(Event) ->
     ScopeFuns = persistent_term:get({golare, process_scope}, #{}),
     ScopeValues = #{K => F() || K := F <- ScopeFuns, is_function(F, 0)},

--- a/src/golare_interface.erl
+++ b/src/golare_interface.erl
@@ -1,0 +1,214 @@
+-module(golare_interface).
+
+-export([exception/3]).
+-export([exception/4]).
+-export([message/1]).
+-export([message/2]).
+-export([request_cowboy/1]).
+-export([thread/0]).
+-export([thread/1]).
+-export([user/1]).
+-export([context/2]).
+-export([extra/1]).
+
+% Types
+-export_type([t/0]).
+
+-type t() :: #{atom() => term()}.
+
+% API
+
+-doc #{equiv => exception(Class, Reason, Stacktrace, #{})}.
+exception(Class, Reason, Stacktrace) ->
+    exception(Class, Reason, Stacktrace, #{}).
+
+-doc """
+Build an [Exception interface](https://develop.sentry.dev/sdk/data-model/event-payloads/exception/).
+
+Captures the exception class, reason, and stacktrace. `Opts` may contain:
+- `mechanism` - the capture mechanism type (default `auto`)
+- `handled` - whether the exception was caught (default `false`)
+- `data` - arbitrary metadata attached to the mechanism
+- `thread_id` - pid of the thread where the exception occurred
+""".
+exception(Class, Reason, Stacktrace, Opts) when is_atom(Class) ->
+    #{
+        exception => [
+            maps:merge(
+                #{
+                    type => Class,
+                    value => format_term(Reason),
+                    mechanism => #{
+                        type => maps:get(mechanism, Opts, auto),
+                        handled => maps:get(handled, Opts, false),
+                        data => safe_json_map(maps:get(data, Opts, #{}))
+                    },
+                    stacktrace => exception_stacktrace(Stacktrace)
+                },
+                #{thread_id => format_term(Pid) || thread_id := Pid <- Opts}
+            )
+        ]
+    }.
+
+-doc """
+Build a [Message interface](https://develop.sentry.dev/sdk/data-model/event-payloads/message/)
+from a pre-formatted message.
+""".
+message(Message) ->
+    #{
+        logentry => #{
+            formatted => iolist_to_binary(Message)
+        }
+    }.
+
+-doc """
+Build a [Message interface](https://develop.sentry.dev/sdk/data-model/event-payloads/message/)
+from a format string and parameters.
+
+The raw `Format` string is preserved for grouping, and `Data` terms are
+formatted as strings for the `params` list.
+""".
+message(Format, Data) ->
+    #{
+        logentry => #{
+            formatted => iolist_to_binary(io_lib:format(Format, Data)),
+            message => iolist_to_binary(Format),
+            params => [format_term(D) || D <- Data]
+        }
+    }.
+
+-doc """
+Build a [Request interface](https://develop.sentry.dev/sdk/data-model/event-payloads/request/)
+from a Cowboy request object.
+
+Extracts method, query string, headers, URL, cookies, and remote address.
+""".
+request_cowboy(Req0) ->
+    {RemoteAddr, _Port} = cowboy_req:peer(Req0),
+    Scope = #{
+        method => cowboy_req:method(Req0),
+        query_string => cowboy_req:qs(Req0),
+        headers => cowboy_req:headers(Req0),
+        env => #{
+            ~"REMOTE_ADDR" => iolist_to_binary(inet:ntoa(RemoteAddr))
+        }
+    },
+    {FinalScope, _Req} = lists:foldl(fun(F, Acc) -> F(Acc) end, {Scope, Req0}, [
+        fun request_cowboy_cookies/1,
+        fun request_cowboy_url/1
+    ]),
+    #{request => FinalScope}.
+
+-doc #{equiv => thread(#{pid => self()})}.
+thread() -> thread(#{pid => self()}).
+
+-doc """
+Build a [Threads interface](https://develop.sentry.dev/sdk/data-model/event-payloads/threads/)
+for a single thread.
+
+Includes the pid as thread id, and the registered name if the process has one.
+Threads are always marked as `current` since Erlang does not have foreground or
+background processes.
+""".
+thread(#{pid := Pid}) when is_pid(Pid) ->
+    Named =
+        case process_info(Pid, registered_name) of
+            {registered_name, Name} -> #{name => Name};
+            [] -> #{}
+        end,
+    #{
+        threads => [
+            Named#{
+                id => format_term(Pid),
+                current => true
+            }
+        ]
+    }.
+
+-doc """
+Build a [User interface](https://develop.sentry.dev/sdk/data-model/event-payloads/user/).
+
+`Data` must contain at least one field such as `id`, `email`, `ip_address`, or
+`username`.
+""".
+user(Data) when map_size(Data) >= 1 ->
+    #{user => safe_json_map(Data)}.
+
+-doc """
+Build a [Response context](https://develop.sentry.dev/sdk/data-model/event-payloads/contexts/#response-context)
+from a Cowboy request and response metadata.
+
+Extracts the response headers. Status code must be explicitly set as
+`status_code` in the context.
+""".
+context(response_cowboy, {Req, Context}) when is_map(Context) ->
+    #{
+        contexts => #{
+            response => #{
+                status_code => maps:get(status_code, Context, null),
+                headers => cowboy_req:resp_headers(Req)
+            }
+        }
+    }.
+
+-doc """
+Build an [Extra Data](https://develop.sentry.dev/sdk/data-model/event-payloads/#optional-attributes)
+interface from an arbitrary map.
+
+Values that are not JSON-encodable are formatted as Erlang terms.
+""".
+extra(Extra) -> #{extra => safe_json_map(Extra)}.
+
+% Internal
+
+exception_stacktrace(Stacktrace) ->
+    #{
+        frames => lists:reverse(lists:map(fun exception_stacktrace_frame/1, Stacktrace))
+    }.
+
+exception_stacktrace_frame({Module, Function, Args, Meta}) ->
+    Arity =
+        case Args of
+            A when is_integer(A) -> A;
+            A when is_list(A) -> length(A)
+        end,
+    File = proplists:get_value(file, Meta),
+    #{
+        in_app =>
+            case File of
+                "/" ++ _ -> true;
+                _ -> false
+            end,
+        function => iolist_to_binary(io_lib:format("~p/~p", [Function, Arity])),
+        filename => Module,
+        abs_path => iolist_to_binary(File),
+        lineno => proplists:get_value(line, Meta)
+    }.
+
+request_cowboy_url({Scope, Req0}) ->
+    URL = uri_string:recompose(#{
+        scheme => cowboy_req:scheme(Req0),
+        host => cowboy_req:host(Req0),
+        port => cowboy_req:port(Req0),
+        path => cowboy_req:path(Req0)
+    }),
+    {Scope#{url => URL}, Req0}.
+
+request_cowboy_cookies({Scope, Req0} = Acc) ->
+    case cowboy_req:parse_cookies(Req0) of
+        [] -> Acc;
+        Cookies -> {Scope#{cookies => maps:from_list(Cookies)}, Req0}
+    end.
+
+format_term(Term) -> iolist_to_binary(io_lib:format("~p", [Term])).
+
+safe_json_map(Map) ->
+    Encoder = fun(Value, Encode) ->
+        try
+            json:encode_value(Value, Encode)
+        catch
+            error:{unsupported_type, Value} ->
+                json:encode(format_term(Value))
+        end
+    end,
+    json:decode(iolist_to_binary(json:encode(Map, Encoder))).

--- a/test/golare_event_SUITE.erl
+++ b/test/golare_event_SUITE.erl
@@ -1,0 +1,260 @@
+-module(golare_event_SUITE).
+
+-compile(nowarn_export_all).
+-compile(export_all).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-define(assertJSON(Term),
+    ?assert(is_binary(iolist_to_binary(json:encode(Term))))
+).
+
+all() ->
+    [
+        base,
+        timestamp_valid,
+        timestamp_invalid,
+        exception,
+        exception_handled,
+        message,
+        request,
+        thread,
+        thread_pid,
+        extra,
+        user,
+        context_response_cowboy
+    ].
+
+% Tests
+
+base(_Config) ->
+    Result = golare:event(#{}, []),
+    ?assertMatch(#{timestamp := TS} when is_integer(TS), Result),
+    ?assertJSON(Result).
+
+timestamp_valid(_Config) ->
+    Result = golare:event(#{timestamp => 1}, []),
+    ?assertMatch(#{timestamp := 1}, Result),
+    ?assertJSON(Result).
+
+timestamp_invalid(_Config) ->
+    ?assertError({invalid_attr, timestamp, foo}, golare:event(#{timestamp => foo}, [])).
+
+exception(_Config) ->
+    {Class, Reason, Stacktrace} =
+        try
+            error({my_exception, data})
+        catch
+            C:R:ST -> {C, R, ST}
+        end,
+    Result = golare:event(#{}, [
+        golare_interface:exception(Class, Reason, Stacktrace)
+    ]),
+    ?assertMatch(
+        #{
+            exception := [
+                #{
+                    type := error,
+                    value := ~"{my_exception,data}",
+                    mechanism := #{type := auto, handled := false},
+                    stacktrace := #{
+                        frames := [
+                            #{},
+                            #{},
+                            #{},
+                            #{}
+                        ]
+                    }
+                }
+            ]
+        },
+        Result
+    ),
+    ?assertJSON(Result).
+
+exception_handled(_Config) ->
+    Result = golare:event(#{}, [
+        golare_interface:exception(error, undef, [], #{handled => true})
+    ]),
+    ?assertMatch(
+        #{
+            exception := [
+                #{
+                    type := error,
+                    value := ~"undef",
+                    mechanism := #{type := auto, handled := true},
+                    stacktrace := #{frames := []}
+                }
+            ]
+        },
+        Result
+    ),
+    ?assertJSON(Result).
+
+message(_Config) ->
+    Result = golare:event(#{}, [
+        golare_interface:message(~"My message with params: ~p, ~p", [1.0, {foo, bar}])
+    ]),
+    ?assertMatch(
+        #{
+            logentry := #{
+                message := ~"My message with params: ~p, ~p",
+                params := [~"1.0", ~"{foo,bar}"]
+            }
+        },
+        Result
+    ),
+    ?assertJSON(Result).
+
+request(_Config) ->
+    Result = golare:event(#{}, [golare_interface:request_cowboy(cowboy_req())]),
+    ?assertMatch(
+        #{
+            request := #{
+                method := ~"POST",
+                query_string := ~"foo=bar&baz=qux",
+                url := ~"https://example.com:9124/path/to/endpoint/123",
+                headers := #{
+                    ~"content-type" := ~"application/json",
+                    ~"content-length" := ~"1098",
+                    ~"x-Custom" := "MyValue"
+                },
+                cookies := #{
+                    ~"PHPSESSID" := ~"298zf09hf012fh2",
+                    ~"csrftoken" := ~"u32t4o3tb3gg43",
+                    ~"_gat" := ~"1"
+                }
+            }
+        },
+        Result
+    ),
+    ?assertJSON(Result).
+
+thread(_Config) ->
+    PidStr = iolist_to_binary(io_lib:format("~p", [self()])),
+    Name = my_name,
+    register(Name, self()),
+    Result = golare:event(#{}, [golare_interface:thread()]),
+    ?assertMatch(
+        #{threads := [#{id := PidStr, current := true, name := Name}]},
+        Result
+    ),
+    ?assertJSON(Result),
+    unregister(Name).
+
+thread_pid(_Config) ->
+    Pid = spawn(fun() -> ok end),
+    PidStr = iolist_to_binary(io_lib:format("~p", [Pid])),
+    Result = golare:event(#{}, [golare_interface:thread(#{pid => Pid})]),
+    ?assertMatch(
+        #{threads := [#{id := PidStr, current := true}]},
+        Result
+    ),
+    ?assertJSON(Result).
+
+extra(_Config) ->
+    Ref = make_ref(),
+    RefStr = iolist_to_binary(io_lib:format("~p", [Ref])),
+    Result = golare:event(#{}, [
+        golare_interface:extra(#{
+            foo => bar,
+            baz => {hello, "wor\"ld"},
+            qux => #{ref => Ref}
+        })
+    ]),
+    ?assertMatch(
+        #{
+            extra := #{
+                ~"foo" := ~"bar",
+                ~"baz" := ~"{hello,\"wor\\\"ld\"}",
+                ~"qux" := #{~"ref" := RefStr}
+            }
+        },
+        Result
+    ),
+    ?assertJSON(Result).
+
+user(_Config) ->
+    Result = golare:event(#{}, [
+        golare_interface:user(#{
+            % Sentry user interaface keys
+            id => 123,
+            email => ~"user@example.com",
+            username => ~"testuser",
+            % Custom keys
+            subscription => ~"premium",
+            account_age => {365, days}
+        })
+    ]),
+    ?assertMatch(
+        #{
+            user := #{
+                ~"id" := 123,
+                ~"email" := ~"user@example.com",
+                ~"username" := ~"testuser",
+                ~"subscription" := ~"premium",
+                ~"account_age" := ~"{365,days}"
+            }
+        },
+        Result
+    ),
+    ?assertJSON(Result).
+
+context_response_cowboy(_Config) ->
+    Req = cowboy_req_with_resp_headers(),
+    Result = golare:event(#{}, [
+        golare_interface:context(response_cowboy, {Req, #{status_code => 200}})
+    ]),
+    ?assertMatch(
+        #{
+            contexts := #{
+                response := #{
+                    status_code := 200,
+                    headers := #{
+                        ~"content-type" := ~"application/json"
+                    }
+                }
+            }
+        },
+        Result
+    ),
+    ?assertJSON(Result).
+
+% Internal
+
+cowboy_req() ->
+    #{
+        pid => self(),
+        port => 9124,
+        scheme => ~"https",
+        version => 'HTTP/2',
+        path => ~"/path/to/endpoint/123",
+        host => ~"example.com",
+        peer => {{127, 0, 0, 1}, 51653},
+        bindings => #{id => <<"2">>},
+        cert => ~"fake_cert",
+        headers => #{
+            ~"content-type" => ~"application/json",
+            ~"content-length" => ~"1098",
+            ~"x-Custom" => "MyValue",
+            ~"cookie" => ~"PHPSESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;"
+        },
+        ref => sentry_mock_server,
+        method => ~"POST",
+        host_info => undefined,
+        path_info => undefined,
+        body_length => 1098,
+        has_body => true,
+        has_read_body => true,
+        qs => ~"foo=bar&baz=qux",
+        sock => {{127, 0, 0, 1}, 9123},
+        streamid => 15
+    }.
+
+cowboy_req_with_resp_headers() ->
+    maps:merge(cowboy_req(), #{
+        resp_headers => #{
+            ~"content-type" => ~"application/json"
+        }
+    }).


### PR DESCRIPTION
This change adds a new function `event/2` that allows users to create events with custom attributes and interfaces that are composable.

`mapz` is included to be able to deeply merge the event and all its interfaces (which can contain deeply nested structures with the same parent keys). If this is not a desirable dependency, it is possible to make a local custom deep merge function.

I might follow this up with another PR that refactors `golare_logger_h` to use this module instead for many attributes.